### PR TITLE
Add live note word count

### DIFF
--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1735,6 +1735,17 @@
   text-decoration-thickness: 1.4px;
 }
 
+.noteEditorStats {
+  flex-shrink: 0;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  color: var(--text-secondary);
+  background: var(--surface-muted);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: right;
+}
+
 #bottomMain {
   flex-shrink: 0;
   margin-top: clamp(12px, 1.5vw, 18px);

--- a/frontend/src/components/MainPage/NoteEditor.js
+++ b/frontend/src/components/MainPage/NoteEditor.js
@@ -1,9 +1,10 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Underline from "@tiptap/extension-underline";
 import AutoCorrectExtension from "./AutoCorrectExtension";
+import { getTextStats } from "./textStats";
 
 function ToolbarButton({ active, disabled, onClick, title, children }) {
   return (
@@ -29,6 +30,7 @@ export default function NoteEditor({
   placeholder = "What is on your mind?",
   editable = true,
 }) {
+  const [textStats, setTextStats] = useState(getTextStats());
   const editor = useEditor(
     {
       extensions: [
@@ -55,7 +57,11 @@ export default function NoteEditor({
           autocapitalize: "sentences",
         },
       },
+      onCreate: ({ editor: ed }) => {
+        setTextStats(getTextStats(ed.getText()));
+      },
       onUpdate: ({ editor: ed }) => {
+        setTextStats(getTextStats(ed.getText()));
         onChange(ed.getHTML());
       },
     },
@@ -166,6 +172,12 @@ export default function NoteEditor({
         </ToolbarButton>
       </div>
       <EditorContent editor={editor} className="noteEditorSurface" />
+      <div className="noteEditorStats" role="status" aria-live="polite">
+        {textStats.words} {textStats.words === 1 ? "word" : "words"}
+        <span aria-hidden="true"> · </span>
+        {textStats.characters}{" "}
+        {textStats.characters === 1 ? "character" : "characters"}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/MainPage/textStats.js
+++ b/frontend/src/components/MainPage/textStats.js
@@ -1,0 +1,8 @@
+export function getTextStats(text = "") {
+  const trimmedText = text.trim();
+
+  return {
+    characters: text.length,
+    words: trimmedText ? trimmedText.split(/\s+/).length : 0,
+  };
+}

--- a/frontend/src/components/MainPage/textStats.test.js
+++ b/frontend/src/components/MainPage/textStats.test.js
@@ -1,0 +1,21 @@
+import { getTextStats } from "./textStats";
+
+describe("getTextStats", () => {
+  test("returns zero counts for empty text", () => {
+    expect(getTextStats()).toEqual({ characters: 0, words: 0 });
+  });
+
+  test("counts words separated by varied whitespace", () => {
+    expect(getTextStats("  one\ntwo\tthree  ")).toEqual({
+      characters: 17,
+      words: 3,
+    });
+  });
+
+  test("keeps punctuation within a word", () => {
+    expect(getTextStats("Hello, world!")).toEqual({
+      characters: 13,
+      words: 2,
+    });
+  });
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add live word and character count display to the note editor
- Adds a new `getTextStats` utility in [textStats.js](https://github.com/asabushaban/clevernote/pull/94/files#diff-3c8f598da154269dd53b7725e04a4320bc78b9882c8cba83ccc7ff315c9ed1c3) that returns word and character counts for a given string, with unit tests covering edge cases.
- Updates [NoteEditor.js](https://github.com/asabushaban/clevernote/pull/94/files#diff-02fe4b2816ecd9fec7efb43badb244c1e09f296e16f380e3f61959c3541a033d) to display a live-updating stats bar showing word and character counts, initialized on editor creation and updated on every edit.
- The stats bar uses `role="status"` and `aria-live="polite"` for accessible announcements and is styled as a muted footer via the new `.noteEditorStats` rule in [MainPage.css](https://github.com/asabushaban/clevernote/pull/94/files#diff-af4705ffde748bca87d8b3f95662201c245b421b1411243b302c9367041ed1f2).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a103fa9.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->