### PR TITLE
Add all-notes and unassigned-note collections

### DIFF
--- a/frontend/src/components/MainPage/BrowseWorkspace.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
 import parseHtml from "html-react-parser";
 import { prettyDateMaker } from "../../helpers";
+import {
+  ALL_NOTES,
+  NO_NOTEBOOK,
+  collectionLabel,
+  isVirtualCollection,
+  notesInCollection,
+} from "./noteCollections";
 
 function textPreview(html, max = 96) {
   if (!html) return "";
@@ -10,13 +17,6 @@ function textPreview(html, max = 96) {
     .replace(/\s+/g, " ")
     .trim();
   return t.length > max ? `${t.slice(0, max)}…` : t;
-}
-
-function notesInScope(notes, notebook) {
-  const all = Object.values(notes);
-  if (notebook === "All Notes") return all;
-  if (!notebook?.id) return all;
-  return all.filter(n => n.notebookId === notebook.id);
 }
 
 function sortNotesByUpdated(list) {
@@ -85,6 +85,8 @@ export function NotebookPickerPanel({
       label:
         openCtx?.type === "allNotes"
           ? "All notes"
+          : openCtx?.type === "noNotebook"
+          ? "No notebook"
           : openCtx?.notebook?.name || "Notebook",
     });
   };
@@ -110,23 +112,31 @@ export function NotebookPickerPanel({
       >
         <div className="notebookPreviewPanelHeader">
           <p className="notebookPreviewPopoverTitle">
-            {sorted.length} note{sorted.length === 1 ? "" : "s"} in this notebook
+            {sorted.length} note{sorted.length === 1 ? "" : "s"} in this{" "}
+            {openCtx?.type === "notebook" ? "notebook" : "collection"}
           </p>
           <button
             type="button"
             className="uiButton uiButtonGhost notebookPreviewOpenNotebookBtn"
             onClick={() =>
               onOpenNotebook(
-                openCtx?.type === "allNotes" ? "All Notes" : openCtx?.notebook
+                openCtx?.type === "allNotes"
+                  ? ALL_NOTES
+                  : openCtx?.type === "noNotebook"
+                  ? NO_NOTEBOOK
+                  : openCtx?.notebook
               )
             }
           >
-            Open notebook
+            Open {openCtx?.type === "notebook" ? "notebook" : "collection"}
           </button>
         </div>
         {sorted.length === 0 ? (
           <div className="notebookPreviewEmpty">
-            No notes yet - create one inside this notebook.
+            No notes yet
+            {openCtx?.type === "notebook"
+              ? " - create one inside this notebook."
+              : "."}
           </div>
         ) : (
           <div className="notebookPreviewLayout">
@@ -178,7 +188,7 @@ export function NotebookPickerPanel({
           <h2 className="browsePanelTitle">Notebooks</h2>
           <p className="browsePanelSubtitle">
             Open a notebook for its list, or use preview to jump directly to a
-            note.
+            note. All notes and No notebook are collections, not notebooks.
           </p>
         </div>
         <div className="browsePanelQuickActions">
@@ -195,7 +205,7 @@ export function NotebookPickerPanel({
           <button
             type="button"
             className="uiButton uiButtonPrimary browsePanelAddNoteBtn"
-            onClick={onCreateNote}
+            onClick={() => onCreateNote(ALL_NOTES)}
           >
             Add note
           </button>
@@ -250,7 +260,7 @@ export function NotebookPickerPanel({
               togglePreview({
                 key: "all",
                 openCtx: { type: "allNotes" },
-                scoped: notesInScope(notes, "All Notes"),
+                scoped: notesInCollection(notes, ALL_NOTES),
               })
             }
           >
@@ -264,9 +274,31 @@ export function NotebookPickerPanel({
           </button>
         </div>
 
+        <div className="notebookPickerCardWrap">
+          <button
+            type="button"
+            className="notebookPickerCard notebookPickerCard--all"
+            onClick={() =>
+              togglePreview({
+                key: "none",
+                openCtx: { type: "noNotebook" },
+                scoped: notesInCollection(notes, NO_NOTEBOOK),
+              })
+            }
+          >
+            <span className="notebookPickerCardIcon" aria-hidden="true">
+              <i className="far fa-folder-open" />
+            </span>
+            <span className="notebookPickerCardName">No notebook</span>
+            <span className="notebookPickerCardMeta">
+              {notesInCollection(notes, NO_NOTEBOOK).length} notes
+            </span>
+          </button>
+        </div>
+
         {list.map(nb => {
           const key = `nb-${nb.id}`;
-          const scoped = notesInScope(notes, nb);
+          const scoped = notesInCollection(notes, nb);
           return (
             <div key={nb.id} className="notebookPickerCardWrap">
               <button
@@ -312,15 +344,11 @@ export function NotesListPanel({
 }) {
   const [page, setPage] = useState(1);
   const pageSize = 12;
-  const title = selectedNotebook?.name || selectedNotebook || "Notes";
-  const list = useMemo(() => {
-    if (selectedNotebook === "All Notes") {
-      return sortNotesByUpdated(Object.values(notes));
-    }
-    return sortNotesByUpdated(Object.values(notes).filter(
-      n => n.notebookId === selectedNotebook?.id
-    ));
-  }, [notes, selectedNotebook]);
+  const title = collectionLabel(selectedNotebook);
+  const list = useMemo(
+    () => sortNotesByUpdated(notesInCollection(notes, selectedNotebook)),
+    [notes, selectedNotebook]
+  );
 
   const totalPages = Math.max(1, Math.ceil(list.length / pageSize));
   const currentPage = Math.min(page, totalPages);
@@ -348,7 +376,7 @@ export function NotesListPanel({
             {list.length} note{list.length === 1 ? "" : "s"}
           </p>
         </div>
-        {selectedNotebook !== "All Notes" ? (
+        {!isVirtualCollection(selectedNotebook) ? (
           <button
             type="button"
             className="browseNotebookMenuBtn"
@@ -365,7 +393,7 @@ export function NotesListPanel({
       <button
         type="button"
         className="uiButton uiButtonPrimary browseNewNoteBtn"
-        onClick={onCreateNote}
+        onClick={() => onCreateNote(selectedNotebook)}
       >
         New note
       </button>

--- a/frontend/src/components/MainPage/BrowseWorkspace.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.jsx
@@ -91,6 +91,11 @@ export function NotebookPickerPanel({
     });
   };
 
+  const closePreview = () => {
+    setExpandedKey(null);
+    setPreviewContext(null);
+  };
+
   const renderPreviewPanel = context => {
     if (!context) return null;
     const { key, scoped, openCtx, label } = context;
@@ -182,7 +187,11 @@ export function NotebookPickerPanel({
   };
 
   return (
-    <div className="browsePanel browsePanel--notebooks">
+    <div
+      className={`browsePanel browsePanel--notebooks${
+        previewContext ? " is-previewing" : ""
+      }`}
+    >
       <header className="browsePanelHeader">
         <div className="browsePanelHeaderText">
           <h2 className="browsePanelTitle">Notebooks</h2>
@@ -251,11 +260,37 @@ export function NotebookPickerPanel({
           </p>
         ) : null}
       </header>
-      <div className="notebookPickerGrid">
-        <div className="notebookPickerCardWrap">
+      <div
+        className={`notebookPickerWorkspace${
+          previewContext ? " is-previewing" : ""
+        }`}
+      >
+        <aside
+          className="notebookPickerRail"
+          aria-label={previewContext ? "Notebook navigation" : undefined}
+        >
+          {previewContext ? (
+            <div className="notebookPickerRailHeader">
+              <button
+                type="button"
+                className="uiButton uiButtonGhost notebookPickerBackToGrid"
+                onClick={closePreview}
+              >
+                <span aria-hidden="true">←</span> All notebooks
+              </button>
+              <span className="notebookPickerRailHint">
+                Choose another collection
+              </span>
+            </div>
+          ) : null}
+          <div className="notebookPickerGrid">
+            <div className="notebookPickerCardWrap">
           <button
             type="button"
-            className="notebookPickerCard notebookPickerCard--all"
+            className={`notebookPickerCard notebookPickerCard--all${
+              expandedKey === "all" ? " is-active" : ""
+            }`}
+            aria-pressed={expandedKey === "all"}
             onClick={() =>
               togglePreview({
                 key: "all",
@@ -277,7 +312,10 @@ export function NotebookPickerPanel({
         <div className="notebookPickerCardWrap">
           <button
             type="button"
-            className="notebookPickerCard notebookPickerCard--all"
+            className={`notebookPickerCard notebookPickerCard--all${
+              expandedKey === "none" ? " is-active" : ""
+            }`}
+            aria-pressed={expandedKey === "none"}
             onClick={() =>
               togglePreview({
                 key: "none",
@@ -303,7 +341,10 @@ export function NotebookPickerPanel({
             <div key={nb.id} className="notebookPickerCardWrap">
               <button
                 type="button"
-                className="notebookPickerCard"
+                className={`notebookPickerCard${
+                  expandedKey === key ? " is-active" : ""
+                }`}
+                aria-pressed={expandedKey === key}
                 onClick={() =>
                   togglePreview({
                     key,
@@ -323,12 +364,14 @@ export function NotebookPickerPanel({
             </div>
           );
         })}
+          </div>
+        </aside>
+        {previewContext ? (
+          <div className="notebookPreviewStage">
+            {renderPreviewPanel(previewContext)}
+          </div>
+        ) : null}
       </div>
-      {previewContext ? (
-        <div className="notebookPreviewStage">
-          {renderPreviewPanel(previewContext)}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/MainPage/BrowseWorkspace.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.jsx
@@ -71,7 +71,7 @@ export function NotebookPickerPanel({
     }
   };
 
-  const togglePreview = ({ key, openCtx, scoped }) => {
+  const togglePreview = ({ key, openCtx }) => {
     if (expandedKey === key) {
       setExpandedKey(null);
       setPreviewContext(null);
@@ -81,7 +81,6 @@ export function NotebookPickerPanel({
     setPreviewContext({
       key,
       openCtx,
-      scoped,
       label:
         openCtx?.type === "allNotes"
           ? "All notes"
@@ -98,7 +97,14 @@ export function NotebookPickerPanel({
 
   const renderPreviewPanel = context => {
     if (!context) return null;
-    const { key, scoped, openCtx, label } = context;
+    const { key, openCtx, label } = context;
+    const collection =
+      openCtx?.type === "allNotes"
+        ? ALL_NOTES
+        : openCtx?.type === "noNotebook"
+        ? NO_NOTEBOOK
+        : openCtx?.notebook;
+    const scoped = notesInCollection(notes, collection);
     const sorted = sortNotesByUpdated(scoped);
     const firstNoteId = sorted[0]?.id || null;
     const activeNoteId = activePreviewNoteByKey[key] || firstNoteId;
@@ -295,7 +301,6 @@ export function NotebookPickerPanel({
               togglePreview({
                 key: "all",
                 openCtx: { type: "allNotes" },
-                scoped: notesInCollection(notes, ALL_NOTES),
               })
             }
           >
@@ -320,7 +325,6 @@ export function NotebookPickerPanel({
               togglePreview({
                 key: "none",
                 openCtx: { type: "noNotebook" },
-                scoped: notesInCollection(notes, NO_NOTEBOOK),
               })
             }
           >
@@ -349,7 +353,6 @@ export function NotebookPickerPanel({
                   togglePreview({
                     key,
                     openCtx: { type: "notebook", notebook: nb },
-                    scoped,
                   })
                 }
               >

--- a/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NotebookPickerPanel } from "./BrowseWorkspace";
+
+jest.mock("html-react-parser", () => value => value);
+
+const notebooks = {
+  10: { id: 10, name: "Work" },
+  20: { id: 20, name: "Personal" },
+};
+
+const notes = {
+  1: {
+    id: 1,
+    notebookId: 10,
+    title: "Work note",
+    content: "<p>Work details</p>",
+    createdAt: "2026-07-23T12:00:00.000Z",
+    updatedAt: "2026-07-23T12:00:00.000Z",
+  },
+  2: {
+    id: 2,
+    notebookId: 20,
+    title: "Personal note",
+    content: "<p>Personal details</p>",
+    createdAt: "2026-07-23T11:00:00.000Z",
+    updatedAt: "2026-07-23T11:00:00.000Z",
+  },
+};
+
+function renderPicker() {
+  return render(
+    <NotebookPickerPanel
+      notebooks={notebooks}
+      notes={notes}
+      onOpenNotebook={jest.fn()}
+      onOpenNote={jest.fn()}
+      onCreateNote={jest.fn()}
+      onCreateNotebook={jest.fn()}
+    />
+  );
+}
+
+test("moves notebook navigation into a rail while a preview is open", () => {
+  const { container } = renderPicker();
+
+  fireEvent.click(screen.getByRole("button", { name: /Work 1 notes/i }));
+
+  expect(
+    container.querySelector(".notebookPickerWorkspace.is-previewing")
+  ).not.toBeNull();
+  expect(
+    screen
+      .getByRole("button", { name: /Work 1 notes/i })
+      .getAttribute("aria-pressed")
+  ).toBe("true");
+  expect(screen.getAllByText("Work details")).toHaveLength(2);
+
+  fireEvent.click(screen.getByRole("button", { name: /Personal 1 notes/i }));
+  expect(screen.getAllByText("Personal details")).toHaveLength(2);
+});
+
+test("restores the full notebook grid from the preview rail", () => {
+  const { container } = renderPicker();
+
+  fireEvent.click(screen.getByRole("button", { name: /Work 1 notes/i }));
+  fireEvent.click(
+    screen.getByRole("button", { name: /All notebooks/i })
+  );
+
+  expect(
+    container.querySelector(".notebookPickerWorkspace.is-previewing")
+  ).toBeNull();
+  expect(
+    screen.queryByRole("button", { name: /All notebooks/i })
+  ).toBeNull();
+});

--- a/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
@@ -41,6 +41,19 @@ function renderPicker() {
   );
 }
 
+function pickerWithNotes(nextNotes) {
+  return (
+    <NotebookPickerPanel
+      notebooks={notebooks}
+      notes={nextNotes}
+      onOpenNotebook={jest.fn()}
+      onOpenNote={jest.fn()}
+      onCreateNote={jest.fn()}
+      onCreateNotebook={jest.fn()}
+    />
+  );
+}
+
 test("moves notebook navigation into a rail while a preview is open", () => {
   const { container } = renderPicker();
 
@@ -74,4 +87,27 @@ test("restores the full notebook grid from the preview rail", () => {
   expect(
     screen.queryByRole("button", { name: /All notebooks/i })
   ).toBeNull();
+});
+
+test("refreshes an open preview when notes change", () => {
+  const { rerender } = render(pickerWithNotes({}));
+
+  fireEvent.click(screen.getByRole("button", { name: /No notebook 0 notes/i }));
+  expect(screen.getByText("No notes yet.")).not.toBeNull();
+
+  rerender(
+    pickerWithNotes({
+      3: {
+        id: 3,
+        notebookId: null,
+        title: "New unassigned note",
+        content: "<p>Loaded after preview opened</p>",
+        createdAt: "2026-07-23T13:00:00.000Z",
+        updatedAt: "2026-07-23T13:00:00.000Z",
+      },
+    })
+  );
+
+  expect(screen.getAllByText("New unassigned note")).toHaveLength(2);
+  expect(screen.getAllByText("Loaded after preview opened")).toHaveLength(2);
 });

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1102,6 +1102,7 @@
 .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   gap: 8px;
   min-height: 0;
   overflow-y: auto;

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1446,10 +1446,13 @@
 @media screen and (max-width: 900px) {
   .notebookPickerWorkspace.is-previewing {
     grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
   }
 
   .notebookPickerWorkspace.is-previewing .notebookPickerRail {
     padding: 10px;
+    max-height: min(190px, 32vh);
   }
 
   .notebookPickerRailHeader {
@@ -1465,22 +1468,27 @@
   .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    max-height: 190px;
+    max-height: 120px;
   }
 
   .notebookPreviewPanel {
-    height: min(64vh, calc(100dvh - 300px));
+    height: 100%;
   }
 
   .notebookPreviewLayout {
     grid-template-columns: 1fr;
+    grid-template-rows: minmax(80px, 38%) minmax(0, 1fr);
   }
 
   .notebookPreviewList--left {
     border-right: 0;
     border-bottom: 1px solid var(--border);
-    max-height: min(220px, 32vh);
-    height: auto;
+    max-height: none;
+    height: 100%;
+  }
+
+  .notebookPreviewFocus {
+    overflow: hidden;
   }
 }
 

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1453,6 +1453,7 @@
   .notebookPickerWorkspace.is-previewing .notebookPickerRail {
     padding: 10px;
     max-height: min(190px, 32vh);
+    overflow: hidden;
   }
 
   .notebookPickerRailHeader {
@@ -1468,7 +1469,9 @@
   .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    max-height: 120px;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
   }
 
   .notebookPreviewPanel {

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1036,6 +1036,59 @@
   border: 1px solid var(--border);
 }
 
+.notebookPickerWorkspace {
+  min-height: 0;
+}
+
+.notebookPickerWorkspace.is-previewing {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  gap: clamp(16px, 2.5vw, 28px);
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.notebookPickerRail {
+  min-width: 0;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerRail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-muted);
+}
+
+.notebookPickerRailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.notebookPickerBackToGrid {
+  justify-content: flex-start;
+  gap: 7px;
+  width: 100%;
+  padding: 9px 10px;
+  font-size: 12px;
+}
+
+.notebookPickerRailHint {
+  padding: 0 4px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .notebookPickerGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
@@ -1046,9 +1099,55 @@
   align-content: start;
 }
 
+.notebookPickerWorkspace.is-previewing .notebookPickerGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 2px 4px 8px 2px;
+}
+
 .notebookPickerCardWrap {
   position: relative;
   overflow: visible;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCard {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  grid-template-areas:
+    "icon name"
+    "icon meta";
+  column-gap: 8px;
+  row-gap: 2px;
+  padding: 11px 10px;
+  border-radius: var(--radius-md);
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCardIcon {
+  grid-area: icon;
+  align-self: center;
+  font-size: 1.05rem;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCardName {
+  grid-area: name;
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCardMeta {
+  grid-area: meta;
+  font-size: 10px;
+}
+
+.notebookPickerCard.is-active {
+  border-color: var(--brand);
+  background: var(--brand-soft);
+  box-shadow: 0 0 0 2px rgba(91, 108, 242, 0.12);
 }
 
 .notebookPickerCard {
@@ -1275,7 +1374,7 @@
 }
 
 .notebookPreviewStage {
-  margin-top: 14px;
+  margin-top: 0;
   flex: 1;
   min-height: 0;
 }
@@ -1345,6 +1444,30 @@
 }
 
 @media screen and (max-width: 900px) {
+  .notebookPickerWorkspace.is-previewing {
+    grid-template-columns: 1fr;
+  }
+
+  .notebookPickerWorkspace.is-previewing .notebookPickerRail {
+    padding: 10px;
+  }
+
+  .notebookPickerRailHeader {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .notebookPickerBackToGrid {
+    width: auto;
+  }
+
+  .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    max-height: 190px;
+  }
+
   .notebookPreviewPanel {
     height: min(64vh, calc(100dvh - 300px));
   }

--- a/frontend/src/components/MainPage/index.js
+++ b/frontend/src/components/MainPage/index.js
@@ -24,6 +24,12 @@ import {
   NotebookPickerPanel,
   NotesListPanel,
 } from "./BrowseWorkspace";
+import {
+  ALL_NOTES,
+  NO_NOTEBOOK,
+  collectionLabel,
+  notebookIdForCollection,
+} from "./noteCollections";
 
 function plainFromHtml(html) {
   if (!html) return "";
@@ -42,7 +48,7 @@ function MainPage() {
   const notebooks = useSelector(state => state.notebooks);
   const selectedNote = useSelector(state => state?.selectedNote);
   const selectedNotebook =
-    useSelector(state => state?.selectedNotebook) || "All Notes";
+    useSelector(state => state?.selectedNotebook) || ALL_NOTES;
 
   const [appPhase, setAppPhase] = useState("notebooks");
 
@@ -271,7 +277,9 @@ function MainPage() {
   const openNoteFromPicker = useCallback(
     (note, ctx) => {
       if (ctx?.type === "allNotes") {
-        dispatch(setSelectedNotebook("All Notes"));
+        dispatch(setSelectedNotebook(ALL_NOTES));
+      } else if (ctx?.type === "noNotebook") {
+        dispatch(setSelectedNotebook(NO_NOTEBOOK));
       } else if (ctx?.type === "notebook" && ctx.notebook) {
         dispatch(setSelectedNotebook(ctx.notebook));
       }
@@ -281,15 +289,23 @@ function MainPage() {
     [dispatch]
   );
 
-  const createNewNote = useCallback(() => {
+  const createNewNote = useCallback(collection => {
+    const targetCollection = collection || ALL_NOTES;
+    const notebookId = notebookIdForCollection(targetCollection);
+    dispatch(setSelectedNotebook(targetCollection));
     dispatch(setSelectedNote(null));
     setNoteContent("");
     setNoteTitle("");
-    setNoteNotebookId(selectedNotebook?.id ?? null);
-    lastSavedRef.current = { id: null, title: "", content: "", notebookId: selectedNotebook?.id ?? null };
+    setNoteNotebookId(notebookId);
+    lastSavedRef.current = {
+      id: null,
+      title: "",
+      content: "",
+      notebookId,
+    };
     setSaveStatus("idle");
     setAppPhase("editor");
-  }, [dispatch, selectedNotebook]);
+  }, [dispatch]);
 
   const createNotebookFromPicker = useCallback(
     async notebookName => {
@@ -458,7 +474,7 @@ function MainPage() {
                   ← Notes
                 </button>
                 <span className="editorFocusNotebookLabel">
-                  {selectedNotebook?.name || selectedNotebook}
+                  {collectionLabel(selectedNotebook)}
                 </span>
               </div>
 

--- a/frontend/src/components/MainPage/noteCollections.js
+++ b/frontend/src/components/MainPage/noteCollections.js
@@ -1,0 +1,30 @@
+export const ALL_NOTES = "All Notes";
+export const NO_NOTEBOOK = "No Notebook";
+
+export function notesInCollection(notes, collection) {
+  const allNotes = Object.values(notes || {});
+
+  if (collection === ALL_NOTES) return allNotes;
+  if (collection === NO_NOTEBOOK) {
+    return allNotes.filter(note => note.notebookId == null);
+  }
+  if (collection?.id != null) {
+    return allNotes.filter(note => note.notebookId === collection.id);
+  }
+
+  return [];
+}
+
+export function isVirtualCollection(collection) {
+  return collection === ALL_NOTES || collection === NO_NOTEBOOK;
+}
+
+export function collectionLabel(collection) {
+  if (collection === ALL_NOTES) return "All notes";
+  if (collection === NO_NOTEBOOK) return "No notebook";
+  return collection?.name || "Notes";
+}
+
+export function notebookIdForCollection(collection) {
+  return isVirtualCollection(collection) ? null : collection?.id ?? null;
+}

--- a/frontend/src/components/MainPage/noteCollections.test.js
+++ b/frontend/src/components/MainPage/noteCollections.test.js
@@ -1,0 +1,43 @@
+import {
+  ALL_NOTES,
+  NO_NOTEBOOK,
+  collectionLabel,
+  isVirtualCollection,
+  notebookIdForCollection,
+  notesInCollection,
+} from "./noteCollections";
+
+const notes = {
+  1: { id: 1, notebookId: 10 },
+  2: { id: 2, notebookId: null },
+  3: { id: 3 },
+  4: { id: 4, notebookId: 20 },
+};
+
+test("All notes contains every note regardless of assignment", () => {
+  expect(notesInCollection(notes, ALL_NOTES).map(note => note.id)).toEqual([
+    1, 2, 3, 4,
+  ]);
+});
+
+test("No notebook contains only unassigned notes", () => {
+  expect(notesInCollection(notes, NO_NOTEBOOK).map(note => note.id)).toEqual([
+    2, 3,
+  ]);
+});
+
+test("real notebooks contain only their assigned notes", () => {
+  expect(notesInCollection(notes, { id: 10, name: "Work" })).toEqual([
+    notes[1],
+  ]);
+});
+
+test("virtual collections are labeled as views and create unassigned notes", () => {
+  expect(isVirtualCollection(ALL_NOTES)).toBe(true);
+  expect(isVirtualCollection(NO_NOTEBOOK)).toBe(true);
+  expect(collectionLabel(ALL_NOTES)).toBe("All notes");
+  expect(collectionLabel(NO_NOTEBOOK)).toBe("No notebook");
+  expect(notebookIdForCollection(ALL_NOTES)).toBeNull();
+  expect(notebookIdForCollection(NO_NOTEBOOK)).toBeNull();
+  expect(notebookIdForCollection({ id: 10 })).toBe(10);
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add 'All notes' and 'No notebook' virtual collection views to the notebook picker
- Introduces a [noteCollections.js](https://github.com/asabushaban/clevernote/pull/96/files#diff-db37770ba6adfde36387da0faafe3b53170349c145f6f8889217f456cdb5d230) module with `ALL_NOTES` and `NO_NOTEBOOK` constants and utilities (`notesInCollection`, `isVirtualCollection`, `collectionLabel`, `notebookIdForCollection`) for consistent collection filtering.
- Adds a 'No notebook' card to the notebook picker grid showing unassigned notes, alongside the existing 'All notes' entry.
- When a preview is open, the picker layout switches to a two-column view with a left navigation rail (collapsing to stacked on screens < 900px); active card state is highlighted.
- New notes created from a virtual collection are saved without a notebook assignment; notes created from a real notebook card are assigned to that notebook.
- The editor header and notes list title now use `collectionLabel` to display 'All notes' or 'No notebook' instead of raw identifiers.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4475bdb.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->