### PR TITLE
Improve notebook preview layout

### DIFF
--- a/frontend/src/components/MainPage/BrowseWorkspace.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.jsx
@@ -91,6 +91,11 @@ export function NotebookPickerPanel({
     });
   };
 
+  const closePreview = () => {
+    setExpandedKey(null);
+    setPreviewContext(null);
+  };
+
   const renderPreviewPanel = context => {
     if (!context) return null;
     const { key, scoped, openCtx, label } = context;
@@ -182,7 +187,11 @@ export function NotebookPickerPanel({
   };
 
   return (
-    <div className="browsePanel browsePanel--notebooks">
+    <div
+      className={`browsePanel browsePanel--notebooks${
+        previewContext ? " is-previewing" : ""
+      }`}
+    >
       <header className="browsePanelHeader">
         <div className="browsePanelHeaderText">
           <h2 className="browsePanelTitle">Notebooks</h2>
@@ -251,11 +260,37 @@ export function NotebookPickerPanel({
           </p>
         ) : null}
       </header>
-      <div className="notebookPickerGrid">
-        <div className="notebookPickerCardWrap">
+      <div
+        className={`notebookPickerWorkspace${
+          previewContext ? " is-previewing" : ""
+        }`}
+      >
+        <aside
+          className="notebookPickerRail"
+          aria-label={previewContext ? "Notebook navigation" : undefined}
+        >
+          {previewContext ? (
+            <div className="notebookPickerRailHeader">
+              <button
+                type="button"
+                className="uiButton uiButtonGhost notebookPickerBackToGrid"
+                onClick={closePreview}
+              >
+                <span aria-hidden="true">←</span> All notebooks
+              </button>
+              <span className="notebookPickerRailHint">
+                Choose another collection
+              </span>
+            </div>
+          ) : null}
+          <div className="notebookPickerGrid">
+            <div className="notebookPickerCardWrap">
           <button
             type="button"
-            className="notebookPickerCard notebookPickerCard--all"
+            className={`notebookPickerCard notebookPickerCard--all${
+              expandedKey === "all" ? " is-active" : ""
+            }`}
+            aria-pressed={expandedKey === "all"}
             onClick={() =>
               togglePreview({
                 key: "all",
@@ -277,7 +312,10 @@ export function NotebookPickerPanel({
         <div className="notebookPickerCardWrap">
           <button
             type="button"
-            className="notebookPickerCard notebookPickerCard--all"
+            className={`notebookPickerCard notebookPickerCard--all${
+              expandedKey === "none" ? " is-active" : ""
+            }`}
+            aria-pressed={expandedKey === "none"}
             onClick={() =>
               togglePreview({
                 key: "none",
@@ -303,7 +341,10 @@ export function NotebookPickerPanel({
             <div key={nb.id} className="notebookPickerCardWrap">
               <button
                 type="button"
-                className="notebookPickerCard"
+                className={`notebookPickerCard${
+                  expandedKey === key ? " is-active" : ""
+                }`}
+                aria-pressed={expandedKey === key}
                 onClick={() =>
                   togglePreview({
                     key,
@@ -323,12 +364,14 @@ export function NotebookPickerPanel({
             </div>
           );
         })}
+          </div>
+        </aside>
+        {previewContext ? (
+          <div className="notebookPreviewStage">
+            {renderPreviewPanel(previewContext)}
+          </div>
+        ) : null}
       </div>
-      {previewContext ? (
-        <div className="notebookPreviewStage">
-          {renderPreviewPanel(previewContext)}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/MainPage/BrowseWorkspace.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.jsx
@@ -71,7 +71,7 @@ export function NotebookPickerPanel({
     }
   };
 
-  const togglePreview = ({ key, openCtx, scoped }) => {
+  const togglePreview = ({ key, openCtx }) => {
     if (expandedKey === key) {
       setExpandedKey(null);
       setPreviewContext(null);
@@ -81,7 +81,6 @@ export function NotebookPickerPanel({
     setPreviewContext({
       key,
       openCtx,
-      scoped,
       label:
         openCtx?.type === "allNotes"
           ? "All notes"
@@ -98,7 +97,14 @@ export function NotebookPickerPanel({
 
   const renderPreviewPanel = context => {
     if (!context) return null;
-    const { key, scoped, openCtx, label } = context;
+    const { key, openCtx, label } = context;
+    const collection =
+      openCtx?.type === "allNotes"
+        ? ALL_NOTES
+        : openCtx?.type === "noNotebook"
+        ? NO_NOTEBOOK
+        : openCtx?.notebook;
+    const scoped = notesInCollection(notes, collection);
     const sorted = sortNotesByUpdated(scoped);
     const firstNoteId = sorted[0]?.id || null;
     const activeNoteId = activePreviewNoteByKey[key] || firstNoteId;
@@ -295,7 +301,6 @@ export function NotebookPickerPanel({
               togglePreview({
                 key: "all",
                 openCtx: { type: "allNotes" },
-                scoped: notesInCollection(notes, ALL_NOTES),
               })
             }
           >
@@ -320,7 +325,6 @@ export function NotebookPickerPanel({
               togglePreview({
                 key: "none",
                 openCtx: { type: "noNotebook" },
-                scoped: notesInCollection(notes, NO_NOTEBOOK),
               })
             }
           >
@@ -349,7 +353,6 @@ export function NotebookPickerPanel({
                   togglePreview({
                     key,
                     openCtx: { type: "notebook", notebook: nb },
-                    scoped,
                   })
                 }
               >

--- a/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NotebookPickerPanel } from "./BrowseWorkspace";
+
+jest.mock("html-react-parser", () => value => value);
+
+const notebooks = {
+  10: { id: 10, name: "Work" },
+  20: { id: 20, name: "Personal" },
+};
+
+const notes = {
+  1: {
+    id: 1,
+    notebookId: 10,
+    title: "Work note",
+    content: "<p>Work details</p>",
+    createdAt: "2026-07-23T12:00:00.000Z",
+    updatedAt: "2026-07-23T12:00:00.000Z",
+  },
+  2: {
+    id: 2,
+    notebookId: 20,
+    title: "Personal note",
+    content: "<p>Personal details</p>",
+    createdAt: "2026-07-23T11:00:00.000Z",
+    updatedAt: "2026-07-23T11:00:00.000Z",
+  },
+};
+
+function renderPicker() {
+  return render(
+    <NotebookPickerPanel
+      notebooks={notebooks}
+      notes={notes}
+      onOpenNotebook={jest.fn()}
+      onOpenNote={jest.fn()}
+      onCreateNote={jest.fn()}
+      onCreateNotebook={jest.fn()}
+    />
+  );
+}
+
+test("moves notebook navigation into a rail while a preview is open", () => {
+  const { container } = renderPicker();
+
+  fireEvent.click(screen.getByRole("button", { name: /Work 1 notes/i }));
+
+  expect(
+    container.querySelector(".notebookPickerWorkspace.is-previewing")
+  ).not.toBeNull();
+  expect(
+    screen
+      .getByRole("button", { name: /Work 1 notes/i })
+      .getAttribute("aria-pressed")
+  ).toBe("true");
+  expect(screen.getAllByText("Work details")).toHaveLength(2);
+
+  fireEvent.click(screen.getByRole("button", { name: /Personal 1 notes/i }));
+  expect(screen.getAllByText("Personal details")).toHaveLength(2);
+});
+
+test("restores the full notebook grid from the preview rail", () => {
+  const { container } = renderPicker();
+
+  fireEvent.click(screen.getByRole("button", { name: /Work 1 notes/i }));
+  fireEvent.click(
+    screen.getByRole("button", { name: /All notebooks/i })
+  );
+
+  expect(
+    container.querySelector(".notebookPickerWorkspace.is-previewing")
+  ).toBeNull();
+  expect(
+    screen.queryByRole("button", { name: /All notebooks/i })
+  ).toBeNull();
+});

--- a/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
+++ b/frontend/src/components/MainPage/BrowseWorkspace.test.jsx
@@ -41,6 +41,19 @@ function renderPicker() {
   );
 }
 
+function pickerWithNotes(nextNotes) {
+  return (
+    <NotebookPickerPanel
+      notebooks={notebooks}
+      notes={nextNotes}
+      onOpenNotebook={jest.fn()}
+      onOpenNote={jest.fn()}
+      onCreateNote={jest.fn()}
+      onCreateNotebook={jest.fn()}
+    />
+  );
+}
+
 test("moves notebook navigation into a rail while a preview is open", () => {
   const { container } = renderPicker();
 
@@ -74,4 +87,27 @@ test("restores the full notebook grid from the preview rail", () => {
   expect(
     screen.queryByRole("button", { name: /All notebooks/i })
   ).toBeNull();
+});
+
+test("refreshes an open preview when notes change", () => {
+  const { rerender } = render(pickerWithNotes({}));
+
+  fireEvent.click(screen.getByRole("button", { name: /No notebook 0 notes/i }));
+  expect(screen.getByText("No notes yet.")).not.toBeNull();
+
+  rerender(
+    pickerWithNotes({
+      3: {
+        id: 3,
+        notebookId: null,
+        title: "New unassigned note",
+        content: "<p>Loaded after preview opened</p>",
+        createdAt: "2026-07-23T13:00:00.000Z",
+        updatedAt: "2026-07-23T13:00:00.000Z",
+      },
+    })
+  );
+
+  expect(screen.getAllByText("New unassigned note")).toHaveLength(2);
+  expect(screen.getAllByText("Loaded after preview opened")).toHaveLength(2);
 });

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1102,6 +1102,7 @@
 .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   gap: 8px;
   min-height: 0;
   overflow-y: auto;

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1446,10 +1446,13 @@
 @media screen and (max-width: 900px) {
   .notebookPickerWorkspace.is-previewing {
     grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
   }
 
   .notebookPickerWorkspace.is-previewing .notebookPickerRail {
     padding: 10px;
+    max-height: min(190px, 32vh);
   }
 
   .notebookPickerRailHeader {
@@ -1465,22 +1468,27 @@
   .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    max-height: 190px;
+    max-height: 120px;
   }
 
   .notebookPreviewPanel {
-    height: min(64vh, calc(100dvh - 300px));
+    height: 100%;
   }
 
   .notebookPreviewLayout {
     grid-template-columns: 1fr;
+    grid-template-rows: minmax(80px, 38%) minmax(0, 1fr);
   }
 
   .notebookPreviewList--left {
     border-right: 0;
     border-bottom: 1px solid var(--border);
-    max-height: min(220px, 32vh);
-    height: auto;
+    max-height: none;
+    height: 100%;
+  }
+
+  .notebookPreviewFocus {
+    overflow: hidden;
   }
 }
 

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1453,6 +1453,7 @@
   .notebookPickerWorkspace.is-previewing .notebookPickerRail {
     padding: 10px;
     max-height: min(190px, 32vh);
+    overflow: hidden;
   }
 
   .notebookPickerRailHeader {
@@ -1468,7 +1469,9 @@
   .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    max-height: 120px;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
   }
 
   .notebookPreviewPanel {

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1036,6 +1036,59 @@
   border: 1px solid var(--border);
 }
 
+.notebookPickerWorkspace {
+  min-height: 0;
+}
+
+.notebookPickerWorkspace.is-previewing {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  gap: clamp(16px, 2.5vw, 28px);
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+
+.notebookPickerRail {
+  min-width: 0;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerRail {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-muted);
+}
+
+.notebookPickerRailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.notebookPickerBackToGrid {
+  justify-content: flex-start;
+  gap: 7px;
+  width: 100%;
+  padding: 9px 10px;
+  font-size: 12px;
+}
+
+.notebookPickerRailHint {
+  padding: 0 4px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .notebookPickerGrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 220px), 1fr));
@@ -1046,9 +1099,55 @@
   align-content: start;
 }
 
+.notebookPickerWorkspace.is-previewing .notebookPickerGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 2px 4px 8px 2px;
+}
+
 .notebookPickerCardWrap {
   position: relative;
   overflow: visible;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCard {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  grid-template-areas:
+    "icon name"
+    "icon meta";
+  column-gap: 8px;
+  row-gap: 2px;
+  padding: 11px 10px;
+  border-radius: var(--radius-md);
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCardIcon {
+  grid-area: icon;
+  align-self: center;
+  font-size: 1.05rem;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCardName {
+  grid-area: name;
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notebookPickerWorkspace.is-previewing .notebookPickerCardMeta {
+  grid-area: meta;
+  font-size: 10px;
+}
+
+.notebookPickerCard.is-active {
+  border-color: var(--brand);
+  background: var(--brand-soft);
+  box-shadow: 0 0 0 2px rgba(91, 108, 242, 0.12);
 }
 
 .notebookPickerCard {
@@ -1275,7 +1374,7 @@
 }
 
 .notebookPreviewStage {
-  margin-top: 14px;
+  margin-top: 0;
   flex: 1;
   min-height: 0;
 }
@@ -1345,6 +1444,30 @@
 }
 
 @media screen and (max-width: 900px) {
+  .notebookPickerWorkspace.is-previewing {
+    grid-template-columns: 1fr;
+  }
+
+  .notebookPickerWorkspace.is-previewing .notebookPickerRail {
+    padding: 10px;
+  }
+
+  .notebookPickerRailHeader {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .notebookPickerBackToGrid {
+    width: auto;
+  }
+
+  .notebookPickerWorkspace.is-previewing .notebookPickerGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    max-height: 190px;
+  }
+
   .notebookPreviewPanel {
     height: min(64vh, calc(100dvh - 300px));
   }


### PR DESCRIPTION
## Summary
- collapse the full notebook grid into a compact, scrollable side rail when a preview opens
- keep every notebook and virtual collection accessible while previewing
- highlight the active collection and allow switching previews without returning to the grid
- add an explicit All notebooks control to restore the default full-grid view
- adapt the focused layout into a compact horizontal rail on smaller screens

## Verification
- npm test -- --watchAll=false --runInBand (9 tests passed)
- npm run build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve notebook preview layout with a two-pane rail and stage view
> - When a notebook is selected for preview, the notebook picker switches from a full grid to a split layout: a scrollable navigation rail on the left and a preview stage on the right.
> - A 'Back to All notebooks' button in the rail header calls a new `closePreview` handler that resets the expanded key and preview context.
> - Selected notebook buttons gain `is-active` styling and `aria-pressed` state to reflect the current selection.
> - On screens narrower than 900px, the rail stacks above the preview stage and the grid reverts to a multi-column layout.
> - The preview panel now recomputes the scoped notes collection from props and `openCtx` on each render, so the preview stays current when the notes prop changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a15045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->