### PR TITLE
Add CVE Check check run agent

### DIFF
--- a/.macroscope/check-run-agents/cve-check.md
+++ b/.macroscope/check-run-agents/cve-check.md
@@ -1,0 +1,83 @@
+---
+title: "CVE Check"
+model: claude-sonnet-4-5
+reasoning: low
+effort: medium
+input: full_diff
+conclusion: failure
+tools:
+  - browse_code
+  - git_tools
+  - web_tools
+  - modify_pr
+---
+
+## Process
+
+You are reviewing a pull request diff against the standards below. IT IS ESSENTIAL THAT YOU ONLY CONSIDER THE STANDARDS ENUMERATED IN THIS FILE. YOU MUST ALWAYS IGNORE ANY / ALL OTHER ISSUES YOU HAPPEN TO NOTICE.
+
+For each potential violation, apply this checklist before commenting:
+
+1. **Introduced by this PR?** Only flag issues introduced or activated by changes in this PR. Do not flag pre-existing issues the diff does not touch.
+2. **Deliberate design choice?** If the pattern appears intentional, suggest documenting the rationale rather than changing the code.
+3. **Explicitly relates to a standard below?** Re-read the standards and confirm you can cite the specific section and quote the specific rule being violated. Unrelated? -> Discard.
+4. **When in doubt, don't comment.** False positives and scope creep damage developer trust. Err on the side of silence.
+
+Submit findings as a **PR review** with inline comments. Finding no violations is the normal outcome — do nothing if the code is clean.
+
+## Comment Format
+
+Write the shortest possible review comment in GitHub-flavored markdown. State the issue first, then briefly describe how to fix it. Phrase as a suggestion, not a demand. End each comment with a collapsible reference to the violated standard.
+
+## Standards
+
+Flag every dependency that this PR **adds or bumps to a version with a known, published security advisory** (CVE / GHSA) whose affected range includes the introduced version.
+
+- Only flag a package@version **actually introduced by this diff**. A dependency that already existed at the same version on the base branch is out of scope, even if vulnerable.
+- A version *bump* introduces the new version — if the new version is (or becomes) vulnerable, flag it. If the bump *fixes* a prior advisory, say nothing.
+- Do not flag a bump that moves a dependency to a non-vulnerable version — that is the desired action.
+- Transitive dependencies introduced via lockfile changes are in scope (they are what actually gets installed).
+- When a lookup is inconclusive or the affected range does not clearly include the introduced version, **do not comment**. Prefer a missed low-confidence finding over a false block.
+
+## How to detect
+
+### 1. Identify manifest / lockfile changes
+
+Inspect only the dependency-declaring files touched by the diff:
+- **npm**: `package.json`, `package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`, `pnpm-lock.yaml`
+- **Go**: `go.mod`, `go.sum`
+- **Python**: `requirements*.txt`, `Pipfile.lock`, `poetry.lock`, `pyproject.toml`
+- **Rust**: `Cargo.toml`, `Cargo.lock`
+- **Java**: `pom.xml`, `build.gradle`, `gradle.lockfile`
+- **Ruby**: `Gemfile`, `Gemfile.lock`
+- **PHP**: `composer.json`, `composer.lock`
+
+Prefer the **lockfile** for the exact resolved version; use the manifest to understand intent when no lockfile is present.
+
+### 2. Extract the introduced `package@version` pairs
+
+From the **added (`+`) lines only**, pull each new `(ecosystem, name, exact version)`:
+- Lockfiles pin exact versions — read the resolved version, not the manifest's range specifier (`^1.2.0`).
+- For a bump, compare the `-` and `+` lines: the value to check is the **new** version on the `+` line.
+- Normalize names to the ecosystem's canonical form (Go module path, npm scoped name `@scope/pkg`, PyPI lowercase-normalized).
+
+### 3. Query the vulnerability databases
+
+Your web access is read-only, GET-style, and **domain-confined**: `web_fetch` can only retrieve hosts on the review agent's allow-list — `github.com` and the package registries (`pypi.org`, `npmjs.com`, `pkg.go.dev`, `crates.io`, `rubygems.org`, and the like). It cannot send a request body or choose an HTTP method, and general advisory hosts such as `osv.dev`, `nvd.nist.gov`, and `snyk.io` are **not** allow-listed, so fetches to them are blocked. Use the source that IS reachable:
+- **GitHub Advisory Database** (`github.com` is allow-listed). Find the advisory for each introduced `name@version`: use `web_search` to locate its GHSA page, then `web_fetch` `https://github.com/advisories/GHSA-...` to read the **CVE alias, severity (CVSS), affected version range, and patched version**. GHSA covers npm, PyPI, Go, Maven, RubyGems, crates.io, Composer, and NuGet and carries the CVE ids, so it is enough to confirm or clear each version.
+- **Cross-check the package's own registry page** (also allow-listed) — `npmjs.com`, `pypi.org`, `pkg.go.dev`, `rubygems.org`, `crates.io` — for a deprecation or security notice on the exact version.
+
+Confirm the introduced version actually falls **within the affected range** (respect `introduced` / `fixed` / `last_affected` boundaries). If it sits at or above the fixed version, it is **not** a finding.
+
+### 4. Report each confirmed vulnerable dependency
+
+One finding per vulnerable package, anchored on its line in the manifest/lockfile. Each comment must state:
+- **Package & introduced version** (`name@version`, ecosystem).
+- **Advisory ID(s)** — `CVE-xxxx-xxxxx` and/or `GHSA-xxxx-xxxx-xxxx`.
+- **Severity** — CVSS score / qualitative level (critical / high / moderate / low).
+- **Affected range** — the vulnerable version range from the advisory.
+- **Fixed version** — the nearest non-vulnerable version to upgrade to.
+
+Keep it to one line of substance plus the collapsible standard reference. Example shape:
+
+> `lodash@4.17.19` — prototype pollution, GHSA-p6mc-m468-83gw / CVE-2020-8203 (high, CVSS 7.4). Affected `>=3.7.0 <4.17.19`; upgrade to `4.17.21`.

--- a/.macroscope/check-run-agents/cve-check.md
+++ b/.macroscope/check-run-agents/cve-check.md
@@ -48,7 +48,7 @@ Inspect only the dependency-declaring files touched by the diff:
 - **Go**: `go.mod`, `go.sum`
 - **Python**: `requirements*.txt`, `Pipfile.lock`, `poetry.lock`, `pyproject.toml`
 - **Rust**: `Cargo.toml`, `Cargo.lock`
-- **Java**: `pom.xml`, `build.gradle`, `gradle.lockfile`
+- **Java**: `pom.xml`, `build.gradle`, `build.gradle.kts`, `settings.gradle.kts`, `gradle/libs.versions.toml`, `gradle.lockfile`
 - **Ruby**: `Gemfile`, `Gemfile.lock`
 - **PHP**: `composer.json`, `composer.lock`
 

--- a/.macroscope/check-run-agents/cve-check.md
+++ b/.macroscope/check-run-agents/cve-check.md
@@ -76,7 +76,7 @@ One finding per vulnerable package, anchored on its line in the manifest/lockfil
 - **Advisory ID(s)** — `CVE-xxxx-xxxxx` and/or `GHSA-xxxx-xxxx-xxxx`.
 - **Severity** — CVSS score / qualitative level (critical / high / moderate / low).
 - **Affected range** — the vulnerable version range from the advisory.
-- **Fixed version** — the nearest non-vulnerable version to upgrade to.
+- **Fixed version** — the nearest non-vulnerable version to upgrade to, or `no fix available`; suggest removal or mitigation when no patched version exists.
 
 Keep it to one line of substance plus the collapsible standard reference. Example shape:
 

--- a/.macroscope/check-run-agents/cve-check.md
+++ b/.macroscope/check-run-agents/cve-check.md
@@ -80,4 +80,4 @@ One finding per vulnerable package, anchored on its line in the manifest/lockfil
 
 Keep it to one line of substance plus the collapsible standard reference. Example shape:
 
-> `lodash@4.17.19` — prototype pollution, GHSA-p6mc-m468-83gw / CVE-2020-8203 (high, CVSS 7.4). Affected `>=3.7.0 <4.17.19`; upgrade to `4.17.21`.
+> `lodash@4.17.18` — prototype pollution, GHSA-p6mc-m468-83gw / CVE-2020-8203 (high, CVSS 7.4). Affected `>=3.7.0 <4.17.19`; upgrade to `4.17.21`.

--- a/.macroscope/check-run-agents/cve-check.md
+++ b/.macroscope/check-run-agents/cve-check.md
@@ -56,7 +56,7 @@ Prefer the **lockfile** for the exact resolved version; use the manifest to unde
 
 ### 2. Extract the introduced `package@version` pairs
 
-From the **added (`+`) lines only**, pull each new `(ecosystem, name, exact version)`:
+From the **added (`+`) lines only**, pull each new version, then use surrounding manifest context to resolve its `(ecosystem, name, exact version)`; the version itself must appear on a `+` line:
 - Lockfiles pin exact versions — read the resolved version, not the manifest's range specifier (`^1.2.0`).
 - For a bump, compare the `-` and `+` lines: the value to check is the **new** version on the `+` line.
 - Normalize names to the ecosystem's canonical form (Go module path, npm scoped name `@scope/pkg`, PyPI lowercase-normalized).


### PR DESCRIPTION
## Summary
- Adds `.macroscope/check-run-agents/cve-check.md`, a Macroscope Check Run Agent that reviews PR diffs for dependencies added or bumped to a version with a known, published security advisory (CVE/GHSA).
- Scoped strictly to newly-introduced `package@version` pairs in manifest/lockfile changes (npm, Go, Python, Rust, Java, Ruby, PHP); pre-existing vulnerable dependencies untouched by the diff are out of scope.
- Looks up advisories via the GitHub Advisory Database and package registries (its only allow-listed, read-only web access) and posts inline PR review comments with CVE/GHSA id, severity, affected range, and fixed version.

Once merged to `dev`, Macroscope will run this Check Run Agent on every future pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CVE Check check-run agent specification
> Adds a new markdown-based check-run agent spec at [cve-check.md](https://github.com/asabushaban/clevernote/pull/101/files#diff-7fb1715f941690c48ff9d3b014759cfa8ca1b6ad350f1976f857f255a0857b74) that instructs an AI agent to scan PRs for vulnerable dependency additions or version bumps.
>
> - Covers manifest and lockfile changes across multiple ecosystems (npm, pip, cargo, etc.), extracting introduced `package@version` pairs from added lines
> - Queries the GitHub Advisory Database and package registries using a defined web-access allowlist to confirm vulnerabilities
> - Defines a strict comment format: only flag confirmed CVEs with severity, CVE ID, affected version range, and a fix recommendation
> - Constrains the agent to enumerated advisory standards only, preventing speculative or unconfirmed flagging
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10022fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->