### PR TITLE
Add dictionary-backed word autocomplete

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,25 @@
 
 # Create React App Template
 
+## Inline autocomplete
+
+The note editor uses the MIT-licensed
+[`@sereneinserenade/tiptap-inline-suggestion`](https://github.com/sereneinserenade/tiptap-inline-suggestion)
+extension because it supports TipTap 2 and renders completions as inline ghost text.
+The dependency is pinned to `0.0.2`; its last published release was in 2023, so
+compatibility should be reviewed when TipTap is upgraded.
+
+Word completions come from the frequency-ranked, ISC-licensed
+[`subtlex-word-frequencies`](https://github.com/words/subtlex-word-frequencies)
+dataset. The editor indexes the 30,000 most common valid entries and begins
+suggesting after three letters. Suggestions complete only the current word and
+do not send note content to a server.
+
+`InlineAutocompleteExtension.js` adds automatic suggestion refresh and keyboard
+controls. Tab or Right Arrow accepts a suggestion, and Escape dismisses it.
+Space always inserts only a space. With no active suggestion, Tab and Right
+Arrow retain their normal browser/editor behavior.
+
 A no-frills template from which to create React + Redux applications with
 [Create React App](https://github.com/facebook/create-react-app).
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@sereneinserenade/tiptap-inline-suggestion": "0.0.2",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
@@ -23,7 +24,8 @@
         "react-router-dom": "^5.3.0",
         "react-scripts": "^5.0.1",
         "redux": "^4.1.1",
-        "redux-thunk": "^2.3.0"
+        "redux-thunk": "^2.3.0",
+        "subtlex-word-frequencies": "2.0.0"
       },
       "devDependencies": {
         "ajv": "^8.17.1",
@@ -3741,6 +3743,19 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag=="
+    },
+    "node_modules/@sereneinserenade/tiptap-inline-suggestion": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@sereneinserenade/tiptap-inline-suggestion/-/tiptap-inline-suggestion-0.0.2.tgz",
+      "integrity": "sha512-0C8yChrIF8X/UnnvEwkvZP0bG2hv8LAhGgaRewGmD/REQqiDsYMK1+foKbOq9rjJF4p4Itc6yYq2TZNSeHDlmQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/sereneinserenade"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.4",
+        "@tiptap/pm": "^2.0.4"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.52",
@@ -18341,6 +18356,11 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/subtlex-word-frequencies": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/subtlex-word-frequencies/-/subtlex-word-frequencies-2.0.0.tgz",
+      "integrity": "sha512-N/8uDDV4zD+PZNOCKvhBfOfSQo2CAKb/icKRsWQpRBNw9nh0Pt+Pt/fQIRaEpaawVIPSlyTekf9zHX/zQi0+Yg=="
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -22545,6 +22565,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag=="
     },
+    "@sereneinserenade/tiptap-inline-suggestion": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@sereneinserenade/tiptap-inline-suggestion/-/tiptap-inline-suggestion-0.0.2.tgz",
+      "integrity": "sha512-0C8yChrIF8X/UnnvEwkvZP0bG2hv8LAhGgaRewGmD/REQqiDsYMK1+foKbOq9rjJF4p4Itc6yYq2TZNSeHDlmQ=="
+    },
     "@sinclair/typebox": {
       "version": "0.34.52",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
@@ -23686,7 +23711,7 @@
       "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
       "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
       "requires": {
-        "loader-utils": "^2.0.0",
+        "loader-utils": "^2.0.4",
         "regex-parser": "^2.2.11"
       }
     },
@@ -32738,6 +32763,11 @@
         "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       }
+    },
+    "subtlex-word-frequencies": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/subtlex-word-frequencies/-/subtlex-word-frequencies-2.0.0.tgz",
+      "integrity": "sha512-N/8uDDV4zD+PZNOCKvhBfOfSQo2CAKb/icKRsWQpRBNw9nh0Pt+Pt/fQIRaEpaawVIPSlyTekf9zHX/zQi0+Yg=="
     },
     "sucrase": {
       "version": "3.35.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@sereneinserenade/tiptap-inline-suggestion": "0.0.2",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -18,7 +19,8 @@
     "react-router-dom": "^5.3.0",
     "react-scripts": "^5.0.1",
     "redux": "^4.1.1",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "subtlex-word-frequencies": "2.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/MainPage/InlineAutocompleteExtension.js
+++ b/frontend/src/components/MainPage/InlineAutocompleteExtension.js
@@ -1,0 +1,147 @@
+import { Extension } from "@tiptap/core";
+import InlineSuggestion from "@sereneinserenade/tiptap-inline-suggestion";
+import { Plugin } from "prosemirror-state";
+import wordFrequencies from "subtlex-word-frequencies";
+
+const MINIMUM_PREFIX_LENGTH = 3;
+const WORD_LIMIT = 30000;
+const WORD_PATTERN = /^[A-Za-z][A-Za-z'-]+$/;
+const wordsByPrefix = wordFrequencies
+  .slice(0, WORD_LIMIT)
+  .reduce((index, { word }) => {
+    if (!WORD_PATTERN.test(word) || word.length <= MINIMUM_PREFIX_LENGTH) {
+      return index;
+    }
+
+    const normalizedWord = word.toLowerCase();
+    const prefix = normalizedWord.slice(0, MINIMUM_PREFIX_LENGTH);
+    if (!index[prefix]) index[prefix] = [];
+    index[prefix].push(normalizedWord);
+    return index;
+  }, {});
+
+export function getInlineCompletion(query) {
+  const partialWord = query.match(/[A-Za-z][A-Za-z'-]*$/)?.[0] || "";
+  if (partialWord.length < MINIMUM_PREFIX_LENGTH) return "";
+
+  const normalizedPartial = partialWord.toLowerCase();
+  const candidates =
+    wordsByPrefix[normalizedPartial.slice(0, MINIMUM_PREFIX_LENGTH)] || [];
+  const matchingWord = candidates.find(
+    word =>
+      word.length > normalizedPartial.length &&
+      word.startsWith(normalizedPartial)
+  );
+  if (!matchingWord) return "";
+
+  const suffix = matchingWord.slice(normalizedPartial.length);
+  return partialWord === partialWord.toUpperCase()
+    ? suffix.toUpperCase()
+    : suffix;
+}
+
+function clearSuggestion(editor) {
+  editor.storage.inlineSuggestion.data = {};
+  editor.view.dispatch(editor.state.tr.setMeta("addToHistory", false));
+}
+
+function acceptSuggestion(editor) {
+  const suggestion = editor.storage.inlineSuggestion.data.currentSuggestion;
+  if (!suggestion) return false;
+
+  editor.storage.inlineSuggestion.data = {};
+  editor.chain().insertContent(suggestion).focus().run();
+  return true;
+}
+
+function moveFocusFromEditor(editor, moveBackward) {
+  const focusableElements = Array.from(
+    document.querySelectorAll(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [contenteditable="true"], [tabindex]:not([tabindex="-1"])'
+    )
+  );
+  const editorIndex = focusableElements.findIndex(
+    element => element === editor.view.dom || element.contains(editor.view.dom)
+  );
+  const nextIndex = editorIndex + (moveBackward ? -1 : 1);
+  const nextElement = focusableElements[nextIndex];
+
+  if (nextElement) {
+    nextElement.focus();
+  } else {
+    editor.commands.blur();
+  }
+}
+
+const InlineAutocompleteControls = Extension.create({
+  name: "inlineAutocompleteControls",
+  priority: 200,
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    let refreshScheduled = false;
+
+    return [
+      new Plugin({
+        view() {
+          return {
+            update(view, previousState) {
+              if (previousState.doc.eq(view.state.doc) || refreshScheduled) return;
+              refreshScheduled = true;
+              Promise.resolve().then(() => {
+                refreshScheduled = false;
+                editor.commands.fetchSuggestion();
+              });
+            },
+          };
+        },
+        props: {
+          handleDOMEvents: {
+            keydown: (_view, event) => {
+              const hasSuggestion = Boolean(
+                editor.storage.inlineSuggestion.data.currentSuggestion
+              );
+
+              if (event.key === "Tab") {
+                event.preventDefault();
+                if (hasSuggestion) {
+                  acceptSuggestion(editor);
+                } else {
+                  moveFocusFromEditor(editor, event.shiftKey);
+                }
+                return true;
+              }
+
+              if (event.key === "ArrowRight" && hasSuggestion) {
+                event.preventDefault();
+                acceptSuggestion(editor);
+                return true;
+              }
+
+              if (event.key === "Escape" && hasSuggestion) {
+                event.preventDefault();
+                clearSuggestion(editor);
+                return true;
+              }
+
+              if (hasSuggestion) {
+                clearSuggestion(editor);
+              }
+
+              return false;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});
+
+const InlineAutocompleteExtension = [
+  InlineAutocompleteControls,
+  InlineSuggestion.configure({
+    fetchAutocompletion: async query => getInlineCompletion(query),
+  }),
+];
+
+export default InlineAutocompleteExtension;

--- a/frontend/src/components/MainPage/InlineAutocompleteExtension.test.js
+++ b/frontend/src/components/MainPage/InlineAutocompleteExtension.test.js
@@ -1,0 +1,128 @@
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import InlineAutocompleteExtension, {
+  getInlineCompletion,
+} from "./InlineAutocompleteExtension";
+
+function createEditor(content = "<p></p>") {
+  const element = document.createElement("div");
+  document.body.appendChild(element);
+
+  return new Editor({
+    element,
+    content,
+    extensions: [StarterKit, ...InlineAutocompleteExtension],
+  });
+}
+
+async function typeAndWait(editor, text) {
+  text.split("").forEach(character => {
+    pressKey(editor, character);
+    editor.commands.insertContent(character);
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function pressKey(editor, key) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+  editor.view.dom.dispatchEvent(event);
+  return event;
+}
+
+describe("inline autocomplete", () => {
+  let editor;
+
+  afterEach(async () => {
+    if (editor) {
+      editor.storage.inlineSuggestion.data = {};
+    }
+    editor?.destroy();
+    document.body.innerHTML = "";
+    await new Promise(resolve => setTimeout(resolve, 80));
+  });
+
+  test("accepts an active suggestion with Tab", async () => {
+    editor = createEditor();
+    await typeAndWait(editor, "comp");
+
+    pressKey(editor, "Tab");
+
+    expect(editor.getText()).toBe("company");
+  });
+
+  test("accepts an active suggestion with Right Arrow", async () => {
+    editor = createEditor();
+    await typeAndWait(editor, "doc");
+
+    pressKey(editor, "ArrowRight");
+
+    expect(editor.getText()).toBe("doctor");
+  });
+
+  test("dismisses an active suggestion with Escape", async () => {
+    editor = createEditor();
+    await typeAndWait(editor, "aut");
+
+    pressKey(editor, "Escape");
+
+    expect(editor.getText()).toBe("aut");
+    expect(editor.storage.inlineSuggestion.data.currentSuggestion).toBeUndefined();
+  });
+
+  test("replaces a suggestion as the user continues typing", async () => {
+    editor = createEditor();
+    await typeAndWait(editor, "sug");
+    expect(editor.storage.inlineSuggestion.data.currentSuggestion).toBe("gest");
+
+    await typeAndWait(editor, "g");
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(editor.storage.inlineSuggestion.data.currentSuggestion).toBe("est");
+  });
+
+  test("returns no suggestion for unrelated text", () => {
+    expect(getInlineCompletion("xyq")).toBe("");
+  });
+
+  test("matches only the current word", () => {
+    expect(getInlineCompletion("A short comp")).toBe("any");
+  });
+
+  test("preserves uppercase input", () => {
+    expect(getInlineCompletion("COM")).toBe("E");
+  });
+
+  test("preserves focus navigation for Tab with no active suggestion", () => {
+    editor = createEditor();
+    const nextButton = document.createElement("button");
+    document.body.appendChild(nextButton);
+    editor.commands.focus();
+
+    pressKey(editor, "Tab");
+
+    expect(document.activeElement).toBe(nextButton);
+  });
+
+  test("lets Space insert only a space when a suggestion is active", async () => {
+    editor = createEditor();
+    await typeAndWait(editor, "doc");
+
+    const event = pressKey(editor, " ");
+    editor.commands.insertContent(" ");
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(editor.getText()).toBe("doc ");
+    expect(editor.storage.inlineSuggestion.data.currentSuggestion).toBeUndefined();
+  });
+
+  test("preserves Right Arrow behavior with no active suggestion", () => {
+    editor = createEditor();
+
+    expect(pressKey(editor, "ArrowRight").defaultPrevented).toBe(false);
+  });
+});

--- a/frontend/src/components/MainPage/MainPage.css
+++ b/frontend/src/components/MainPage/MainPage.css
@@ -1870,6 +1870,14 @@
   text-decoration-thickness: 1.4px;
 }
 
+.noteEditorSurface [data-inline-suggestion]::after {
+  content: attr(data-inline-suggestion);
+  color: var(--text-secondary);
+  font-style: italic;
+  opacity: 0.58;
+  pointer-events: none;
+}
+
 .noteEditorStats {
   flex-shrink: 0;
   padding: 8px 14px;

--- a/frontend/src/components/MainPage/NoteEditor.js
+++ b/frontend/src/components/MainPage/NoteEditor.js
@@ -4,6 +4,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Underline from "@tiptap/extension-underline";
 import AutoCorrectExtension from "./AutoCorrectExtension";
+import InlineAutocompleteExtension from "./InlineAutocompleteExtension";
 import { getTextStats } from "./textStats";
 
 function ToolbarButton({ active, disabled, onClick, title, children }) {
@@ -41,6 +42,7 @@ export default function NoteEditor({
         }),
         Underline,
         AutoCorrectExtension,
+        ...InlineAutocompleteExtension,
         Placeholder.configure({
           placeholder,
         }),


### PR DESCRIPTION
Cherry-picked from `feature/word-autocomplete` onto latest `main` (which already includes the CVE Check and Review Triage check run agents) so both new check run agents have real diff content to run and triage against.

## Summary
- Adds an inline, dictionary-backed word autocomplete suggestion to the note editor (Tiptap extension), accepting with Tab / Right Arrow and dismissing with Escape.
- Backed by `subtlex-word-frequencies` for suggestion ranking and `@sereneinserenade/tiptap-inline-suggestion`.

## Testing
- `InlineAutocompleteExtension.test.js` — 10/10 passing locally.

Purpose of this PR: exercise the new `cve-check` and `review-triage` check run agents end-to-end and triage their output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dictionary-backed word autocomplete to the note editor
> - Builds a client-side prefix index of up to 30,000 words from the `subtlex-word-frequencies` dataset on module load, bucketed by 3-letter prefix for fast lookup.
> - Adds [`InlineAutocompleteExtension.js`](https://github.com/asabushaban/clevernote/pull/105/files#diff-68cee00853ba228c3d6ba8591e2091915919f1dea17b3a95ec42e4bce6248dba) using `@sereneinserenade/tiptap-inline-suggestion` to show ghost-text completions after 3 letters are typed, with no server calls.
> - Keyboard controls: Tab or Right Arrow accepts, Escape dismisses, Tab/Shift+Tab moves editor focus when no suggestion is active.
> - Styles ghost text via a CSS `::after` pseudo-element in [`MainPage.css`](https://github.com/asabushaban/clevernote/pull/105/files#diff-af4705ffde748bca87d8b3f95662201c245b421b1411243b302c9367041ed1f2) using secondary color, italic, and reduced opacity.
> - Risk: prefix index construction runs synchronously on module load and may add startup latency proportional to the 30,000-word dataset.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized be8f47b. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->